### PR TITLE
feat(transform-custom-elements): recurse to transform elements in slots

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,6 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
 indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*
 !.editorconfig
 !.gitignore
+!.gitattributes
 !.rollup.js
 !.tape.js
 !.travis.yml

--- a/.tape.js
+++ b/.tape.js
@@ -8,6 +8,19 @@ module.exports = {
 			preserve: true
 		}
 	},
+	'basic-nested': {
+		message: 'supports { transformSlots: true } usage',
+		options: {
+			transformSlots: true
+		}
+	},
+	'basic-nested:preserve': {
+		message: 'supports { transformSlots: true, preserve: true } usage',
+		options: {
+			transformSlots: true,
+			preserve: true
+		}
+	},
 	'link': {
 		message: 'supports <link rel="html" href="some/path" /> usage'
 	},

--- a/README.md
+++ b/README.md
@@ -174,6 +174,62 @@ The `cwd` option defines and overrides the current working directory of
 phtmlInclude({ cwd: '/some/absolute/path' });
 ```
 
+### transformSlots
+
+Custom elements, that populate slots of a parent custom element, are not replaced with their defined custom element templates.
+
+`transformSlots` enables this nested replacement.
+
+```js
+phtmlInclude({ transformSlots: true });
+```
+
+```html
+<!-- definitions.html -->
+
+<define tag="pricing-tier">
+  <header>
+    <h1>$<slot name="price" /></h1>
+    <h2><slot name="name" /></h2>
+  </header>
+  <div class="features">
+    <slot name="features" />
+  </div>
+</define>
+
+<define tag="call-to-action">
+  <button class="call-to-action">
+    <slot name="text">Click Me</slot>
+  </button>
+</define>
+
+<!-- index.html -->
+
+<link rel="html" href="definitions.html" />
+<pricing-tier slot-name="Basic">
+  <slot name="price">10</slot>
+  <div slot="features">
+    <ul>
+      <li>Unlimited foo</li>
+    </ul>
+    <call-to-action slot-text="Buy now"></call-to-action>
+  </div>
+</pricing-tier>
+
+<!-- becomes -->
+
+<header>
+  <h1>$10</h1>
+  <h2>Basic</h2>
+</header>
+<div class="features">
+  <ul>
+    <li>Unlimited foo</li>
+  </ul>
+  <button class="call-to-action">Buy now</button>
+</div>
+```
+
 [cli-img]: https://img.shields.io/travis/phtmlorg/phtml-define.svg
 [cli-url]: https://travis-ci.org/phtmlorg/phtml-define
 [git-img]: https://img.shields.io/badge/support-chat-blue.svg

--- a/src/lib/transform-custom-elements.js
+++ b/src/lib/transform-custom-elements.js
@@ -30,6 +30,8 @@ export default function transformCustomElements (root, opts, defines) {
 			transformAttrValues(child.attrs, customSlots);
 		});
 
+		const { parent } = node;
+
 		if (opts.preserve) {
 			const template = new Element({
 				name: 'template',
@@ -40,6 +42,10 @@ export default function transformCustomElements (root, opts, defines) {
 			node.nodes.push(template, ...defineClone.nodes);
 		} else {
 			node.replaceWith(...defineClone.nodes);
+		}
+
+		if (opts.transformSlots) {
+			transformCustomElements(parent, opts, defines);
 		}
 	});
 }

--- a/test/basic-nested.expect.html
+++ b/test/basic-nested.expect.html
@@ -1,0 +1,32 @@
+<define tag="page-layout">
+	<div class="container">
+		<slot name="contents" />
+	</div>
+</define>
+
+<define tag="two-column">
+	<div class="row">
+		<div class="col-6">
+			<slot name="left" />
+		</div>
+
+		<div class="col-6">
+			<slot name="right" />
+		</div>
+	</div>
+</define>
+
+
+	<div class="container">
+		
+	<div class="row">
+		<div class="col-6">
+			<h1>Left Column</h1>
+		</div>
+
+		<div class="col-6">
+			<h1>Right Column</h1>
+		</div>
+	</div>
+
+	</div>

--- a/test/basic-nested.html
+++ b/test/basic-nested.html
@@ -1,0 +1,25 @@
+<define tag="page-layout">
+	<div class="container">
+		<slot name="contents" />
+	</div>
+</define>
+
+<define tag="two-column">
+	<div class="row">
+		<div class="col-6">
+			<slot name="left" />
+		</div>
+
+		<div class="col-6">
+			<slot name="right" />
+		</div>
+	</div>
+</define>
+
+<page-layout>
+	<two-column slot="contents">
+		<h1 slot="left">Left Column</h1>
+
+		<h1 slot="right">Right Column</h1>
+	</two-column>
+</page-layout>

--- a/test/basic-nested.preserve.expect.html
+++ b/test/basic-nested.preserve.expect.html
@@ -1,0 +1,43 @@
+<define tag="page-layout">
+	<div class="container">
+		<slot name="contents" />
+	</div>
+</define>
+
+<define tag="two-column">
+	<div class="row">
+		<div class="col-6">
+			<slot name="left" />
+		</div>
+
+		<div class="col-6">
+			<slot name="right" />
+		</div>
+	</div>
+</define>
+
+<page-layout><template>
+	<two-column slot="contents">
+		<h1 slot="left">Left Column</h1>
+
+		<h1 slot="right">Right Column</h1>
+	</two-column>
+</template>
+	<div class="container">
+		<two-column><template>
+		<h1 slot="left">Left Column</h1>
+
+		<h1 slot="right">Right Column</h1>
+	</template>
+	<div class="row">
+		<div class="col-6">
+			<h1>Left Column</h1>
+		</div>
+
+		<div class="col-6">
+			<h1>Right Column</h1>
+		</div>
+	</div>
+</two-column>
+	</div>
+</page-layout>

--- a/test/basic-nested.preserve.html
+++ b/test/basic-nested.preserve.html
@@ -1,0 +1,25 @@
+<define tag="page-layout">
+	<div class="container">
+		<slot name="contents" />
+	</div>
+</define>
+
+<define tag="two-column">
+	<div class="row">
+		<div class="col-6">
+			<slot name="left" />
+		</div>
+
+		<div class="col-6">
+			<slot name="right" />
+		</div>
+	</div>
+</define>
+
+<page-layout>
+	<two-column slot="contents">
+		<h1 slot="left">Left Column</h1>
+
+		<h1 slot="right">Right Column</h1>
+	</two-column>
+</page-layout>


### PR DESCRIPTION
I just wanted to start out saying, thanks for making this ecosystem of tools. `phtml` is really cool! The way it enables web component-like markup without any JS is really powerful for mockups/wireframing or getting a front-end dev, who is not used to JS frameworks, thinking in terms of components.

I'm planning on using it to build out a library of custom elements to build wireframes in HTML instead of a tool like Adobe XD.

---

This PR adds the ability to use custom elements inside the slots of other custom elements when they are being used.

I wanted to be able to define a collection of custom elements and compose them all together with their slots.

A simple example is included in the `README.md` but here's another using bootstrap classes (which I added as a test):

```html
<!-- definitions.html -->

<define tag="page-layout">
  <div class="container">
    <slot name="contents" />
  </div>
</define>

<define tag="two-column">
  <div class="row">
    <div class="col-6">
      <slot name="left" />
    </div>

    <div class="col-6">
      <slot name="right" />
    </div>    
  </div>
</define>

<!-- index.html -->

<page-layout>
  <div slot-name="contents">
    <two-column>
      <h1 slot-name="left">Left Column</slot>

      <h1 slot-name="right">Right Column</slot>
    </two-column>
  </div>
</page-layout>

<!-- result -->

<div class="container">		
	<div class="row">
		<div class="col-6">
			<h1>Left Column</h1>
		</div>

		<div class="col-6">
			<h1>Right Column</h1>
		</div>
	</div>
</div>
```

This also works with `{ preserve: true }`.

There is 1 failing test which looks to be an issue with whitespace (newline / linefeed).
I believe this is because the file in the gist uses both `\r\n` and `\n` and the expected result uses one or the other depending on the OS (in Windows, Git creates the file using `\r\n` and converts those back to `\n` when committing).

```
× phtml-define supports <link rel="html" href="https://some/url" /> usage

Expected: \r\n\r\n\t<header>\r\n\t\t<h1>$10</h1>\r\n\t\t<h2>Basic</h2>\r\n\t</header>\r\n\t<div class=\"features\">\r\n\t\t<ul>\r\n\t\t<li>Unlimited foo</li>\r\n\t</ul>\r\n\t</div>\r\n\r\n<img src=\"images/image.webp\">

Received: \r\n\n\t<header>\n\t\t<h1>$10</h1>\n\t\t<h2>Basic</h2>\n\t</header>\n\t<div class=\"features\">\n\t\t<ul>\r\n\t\t<li>Unlimited foo</li>\r\n\t</ul>\n\t</div>\n\r\n<img src=\"images/image.webp\">
```

I removed the `end_of_line = lf` entry in the `.editorconfig` which is not recommended when using Git. A better option is using [.gitattributes](https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings#example) (which I added) to ensure all `\r\n` get converted back to `\n` on commit, even if the dev doesn't have this set in their Git config.